### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,12 @@
       {
         "url": "https://api.company-information.service.gov.uk/.*",
         "methods": ["GET"],
-        "timeout": 30
+        "timeout": 30,
+        "settingsInjection": {
+          "api_key": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request introduces a configuration update to the `manifest.json` file, specifically enhancing how API keys are injected into outgoing requests for the Company Information Service. The change improves security and flexibility by allowing the API key to be dynamically set in the request header.

API key injection configuration:

* Added a `settingsInjection` section to the Company Information Service API configuration, enabling the `api_key` to be automatically included in the `Authorization` header for requests.